### PR TITLE
fix frontend using wrong property name

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,5 +1,7 @@
 cd frontend
 
-pnpm run lint:fix
+CI=true pnpm i --no-frozen-lockfile
+
+CI=true pnpm run lint:fix
 
 git update-index --again

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         specifier: ^3.8.2
         version: 3.8.2
       prettier-eslint:
-        specifier: ^16.4.2
+        specifier: ^16.3.0
         version: 16.4.2(typescript@5.9.3)
       typescript:
         specifier: ~5.9.3
@@ -1016,6 +1016,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+allowBuilds:
+  esbuild: true
 onlyBuiltDependencies:
   - esbuild

--- a/frontend/src/components/Course/Course.tsx
+++ b/frontend/src/components/Course/Course.tsx
@@ -2,7 +2,7 @@ import { useSettings } from '@providers/SettingsProvider';
 import { memo, useCallback } from 'react';
 
 export interface CourseType {
-  name: string;
+  title: string;
   description: string;
   image?: string;
   price: number;
@@ -34,7 +34,7 @@ const Course = ({ course, width, height, onClick }: CourseProps) => {
             className="rounded-md object-cover w-full h-full z-10 group-hover:scale-105 transition-transform duration-300"
             draggable={false}
             src={'/pxsng.svg'}
-            alt={course.name}
+            alt={course.title}
             width={width || 200}
             height={height || 200}
           />
@@ -44,7 +44,7 @@ const Course = ({ course, width, height, onClick }: CourseProps) => {
             className="text-xl font-bold text-font-light truncate transition-colors duration-300"
             data-theme={theme}
           >
-            {course.name}
+            {course.title}
           </div>
           <div
             className="group-hover:block hidden truncate text-sm mt-1 text-font-light"


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the frontend build process and the `Course` component. The most significant changes include updating the pre-commit hook to ensure dependencies are installed in CI environments, updating the `Course` component to use `title` instead of `name`, and making adjustments to the workspace and lockfile for dependency management.

**Build and Dependency Management:**

* Updated the `frontend/.husky/pre-commit` script to install dependencies with `pnpm i --no-frozen-lockfile` under the `CI=true` environment variable before running lint fixes, ensuring a consistent environment for linting in CI and pre-commit hooks.
* Added an `allowBuilds` section for `esbuild` in `frontend/pnpm-workspace.yaml` to explicitly permit its builds, improving workspace configuration.
* Marked `@ungap/structured-clone@1.3.0` as deprecated in `frontend/pnpm-lock.yaml` and provided a recommendation to update to a safer version, increasing visibility of potential security risks.
* Changed the `prettier-eslint` dependency specifier from `^16.4.2` to `^16.3.0` in `frontend/pnpm-lock.yaml`, which may help with compatibility or stability.

**Component Refactoring:**

* Refactored the `Course` component in `frontend/src/components/Course/Course.tsx` to use the `title` property instead of `name` for course objects, updating all relevant references and props for clarity and consistency. [[1]](diffhunk://#diff-643a56343584da4049773024fe5bcc608a6e8c7eb639c18e1b203889db0fe546L5-R5) [[2]](diffhunk://#diff-643a56343584da4049773024fe5bcc608a6e8c7eb639c18e1b203889db0fe546L37-R37) [[3]](diffhunk://#diff-643a56343584da4049773024fe5bcc608a6e8c7eb639c18e1b203889db0fe546L47-R47)